### PR TITLE
Fix：移除ICE候选者固定延迟并增强WebRTC连接流程以及一些杂项

### DIFF
--- a/lib/entities/session.dart
+++ b/lib/entities/session.dart
@@ -44,7 +44,7 @@ enum StreamingSessionConnectionState {
   answerSent,
   answerReceived,
   // TODO: use RTCPeerConnectionState instead.
-  connceting,
+  connecting,
   connected,
   disconnecting,
   disconnected,


### PR DESCRIPTION
## 解决了什么问题

此PR主要解决了在 `session.dart` 中，控制端和被控端发送ICE候选信息时使用了固定1秒延迟的问题 。这个延迟影响了WebRTC连接建立的速度。

## 主要做了哪些修改


1.  **移除了ICE候选者发送的固定1秒延迟**：
    *   在 `startRequest()` (控制端) 和 `acceptRequest()` (被控端) 的 `onIceCandidate` 回调中，ICE候选者现在会立即发送。
    *   添加了对 `candidate == null` 的处理，以应对ICE收集完成的情况。

2.  **优化了连接成功的判断逻辑**：
    *   连接状态现在主要依赖于DataChannel的成功打开以及后续成功的Ping-Pong交换，而不是单纯依赖 `RTCPeerConnectionStateConnected` 事件。

3.  **增强了ICE候选者的处理和SDP修改逻辑**：
    *   改进了 `onCandidateReceived` 方法，使其在PeerConnection未完全就绪时能更好地缓存候选者。
    *   重构了 `_fixSdp` 方法，以更可靠的方式修改SDP来设置码率等参数。

4.  **梳理和加强了会话关闭与资源释放 (`close()` / `stop()`)**：
    *   优化了 `isClosing_` 标志的使用和 `_pingTimeoutTimer` 的取消逻辑，确保资源（如PeerConnection、DataChannel、定时器、硬件钩子等）能被正确及时地释放。
    *   确保了 `StreamingManager/StreamedManager.stopStreaming` 在 `stop()` 流程中被调用。

5.  **提升了DataChannel消息处理的健壮性**：
    *   增加了连接状态检查和JSON解析的错误处理。
    *   修正并明确了Ping-Pong信令的交互逻辑。

6.  **改进了剪贴板同步功能**：
    *   增加了对全局剪贴板同步开关 `StreamingSettings.useClipBoard` 的检查。
    *   优化了 `_syncClipboard`逻辑，仅在剪贴板内容非空且发生变化时才进行同步。

7.  **其他代码质量改进**：
    *   包括拼写修正`connceting` -> `connecting`、日志增强和注释完善。
